### PR TITLE
Update to WildFly 10.0.0.CR2, including new Hibernate versions and more

### DIFF
--- a/arqullian-integration-exploded-tests/pom.xml
+++ b/arqullian-integration-exploded-tests/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.wildfly.extras.db_bootstrap</groupId>
 		<artifactId>db-bootstrap-subsystem-parent</artifactId>
-		<version>1.0.7</version>
+		<version>1.0.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/arqullian-integration-tests/pom.xml
+++ b/arqullian-integration-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wildfly.extras.db_bootstrap</groupId>
         <artifactId>db-bootstrap-subsystem-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -88,14 +88,13 @@
         	<systemPath>${project.root}/test-ear/target/wildfly-arquillian-integration-exploded-ear.ear</systemPath>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>${version.wildfly}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-7.0</artifactId>
-            <version>1.0.1.Final</version>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -103,18 +102,16 @@
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
-            <version>${version.arquillian}</version>            
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
             <scope>test</scope>
-            <version>${version.arquillian}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
-            <version>2.0.1</version>
+            <version>2.2.0</version>
             <type>pom</type>
         </dependency>
     </dependencies>

--- a/arqullian-integration-tests/src/test/java/org/wildfly/extras/db_bootstrap/databasebootstrap/PersonSchema.java
+++ b/arqullian-integration-tests/src/test/java/org/wildfly/extras/db_bootstrap/databasebootstrap/PersonSchema.java
@@ -18,6 +18,7 @@ package org.wildfly.extras.db_bootstrap.databasebootstrap;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.wildfly.extras.db_bootstrap.dbutils.HibernateTestUtil;
 
 /**
@@ -72,7 +73,7 @@ public class PersonSchema {
             callback.execute(session);
             tx.commit();
         } finally {
-            if (tx.isActive()) {
+            if (tx.getStatus() == TransactionStatus.ACTIVE) {
                 tx.rollback();
             }
             if (session != null) {

--- a/arqullian-integration-tests/src/test/resources/arquillian.xml
+++ b/arqullian-integration-tests/src/test/resources/arquillian.xml
@@ -18,7 +18,7 @@
 -->
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="wildfly-managed-8.1.0" default="true">
+    <container qualifier="wildfly-managed-10.0.0" default="true">
         <configuration>
             <property name="jbossHome">${wildfly.home}</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wildfly.extras.db_bootstrap</groupId>
         <artifactId>db-bootstrap-subsystem-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -41,8 +41,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -58,7 +58,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <arquillian.launch>wildfly-managed-8.1.0</arquillian.launch>
+                        <arquillian.launch>wildfly-managed-10.0.0</arquillian.launch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -67,15 +67,15 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
             <type>pom</type>
             <scope>test</scope>

--- a/extension/src/main/java/org/wildfly/extras/db_bootstrap/DbBootstrapScanDetectorProcessor.java
+++ b/extension/src/main/java/org/wildfly/extras/db_bootstrap/DbBootstrapScanDetectorProcessor.java
@@ -38,6 +38,7 @@ import org.hibernate.Transaction;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -269,7 +270,7 @@ class DbBootstrapScanDetectorProcessor implements DeploymentUnitProcessor {
             tx.rollback();
             throw e;
         } finally {
-            if (tx.isActive()) {
+            if (tx.getStatus() == TransactionStatus.ACTIVE) {
                 tx.commit();
             }
             session.close();

--- a/integrate/pom.xml
+++ b/integrate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wildfly.extras.db_bootstrap</groupId>
         <artifactId>db-bootstrap-subsystem-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -34,8 +34,8 @@
     <properties>
         <project.root>${basedir}/..</project.root>
         <version.rhino.js>1.7R2</version.rhino.js>
-        <version.org.jboss.jandex>1.0.3.Final</version.org.jboss.jandex>
-        <version.org.apache.ant>1.8.2</version.org.apache.ant>
+        <version.org.jboss.jandex>2.0.0.CR1</version.org.jboss.jandex>
+        <version.org.apache.ant>1.9.6</version.org.apache.ant>
         <module.dest.directory>${wildfly.home}/modules/org/wildfly/extras/db_bootstrap/main</module.dest.directory>
         <!-- generated configs root dirs -->
         <generated.configs>${basedir}/target/generated-configs</generated.configs>

--- a/integrate/src/main/resources/modules/org/wildfly/extras/db_bootstrap/main/module.xml
+++ b/integrate/src/main/resources/modules/org/wildfly/extras/db_bootstrap/main/module.xml
@@ -2,15 +2,16 @@
 
 <module xmlns="urn:jboss:module:1.3" name="org.wildfly.extras.db_bootstrap">
     <resources>
-        <artifact name="org.hibernate:hibernate-core:4.3.5.Final"/>
-        <artifact name="org.hibernate:hibernate-validator-annotation-processor:5.1.0.Final" />
-        <artifact name="org.hibernate.common:hibernate-commons-annotations:4.0.4.Final" />
+        <artifact name="org.hibernate:hibernate-core:5.0.1.Final"/>
+        <artifact name="org.hibernate:hibernate-validator-annotation-processor:5.2.1.Final" />
+        <artifact name="org.hibernate.common:hibernate-commons-annotations:5.0.0.Final" />
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
        <module name="javax.annotation.api"/>
         <module name="javax.api"/>
+        <module name="javax.xml.bind.api"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<artifactId>jboss-parent</artifactId>
 		<groupId>org.jboss</groupId>
-		<version>14</version>
+		<artifactId>jboss-parent</artifactId>
+		<version>16</version>
 	</parent>
 	<groupId>org.wildfly.extras.db_bootstrap</groupId>
 	<artifactId>db-bootstrap-subsystem-parent</artifactId>
-	<version>1.0.7</version>
+	<version>1.0.8</version>
 	<packaging>pom</packaging>
 	<name>DB_BOOTSTRAP</name>
 	<description>Database bootstrap deployment detector subsystem</description>
@@ -38,20 +38,12 @@
 		</license>
 	</licenses>
 	<properties>
-		<version.org.jboss.logging.processor>1.1.0.Final</version.org.jboss.logging.processor>
-		<version.shrinkwrap.resolvers>1.0.0-beta-5</version.shrinkwrap.resolvers>
-		<version.org.jboss.logmanager>1.4.1.Final</version.org.jboss.logmanager>
-		<version.org.jboss.logging>3.1.3.GA</version.org.jboss.logging>
-		<version.wildfly>8.1.0.Final</version.wildfly>
-		<version.org.hibernate>4.3.5.Final</version.org.hibernate>
-		<version.org.hibernate.validator>5.1.0.Final</version.org.hibernate.validator>
-		<version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
+		<version.wildfly>10.0.0.CR2</version.wildfly>
+		<version.org.hibernate>5.0.1.Final</version.org.hibernate>
+		<version.org.hibernate.validator>5.2.1.Final</version.org.hibernate.validator>
 		<project.root>${basedir}</project.root>
 		<linkXRef>false</linkXRef>
 		<maven.compiler.encoding>UTF-8</maven.compiler.encoding>
-		<version.org.jboss.modules>1.3.0.Beta2</version.org.jboss.modules>
-		<version.junit>4.11</version.junit>
-		<version.arquillian>1.1.2.Final</version.arquillian>
 		<surefire.system.args>-da ${surefire.jpda.args}</surefire.system.args>
 		<surefire.jpda.args />
 		<wildfly.home>${project.root}/target/wildfly-${version.wildfly}</wildfly.home>
@@ -98,86 +90,44 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.scannotation</groupId>
-				<artifactId>scannotation</artifactId>
-				<version>1.0.3</version>
-			</dependency>
-			<dependency>
 				<groupId>org.wildfly</groupId>
-				<artifactId>wildfly-server</artifactId>
-				<version>${version.wildfly}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.wildfly</groupId>
-				<artifactId>wildfly-subsystem-test</artifactId>
+				<artifactId>wildfly-parent</artifactId>
 				<type>pom</type>
-				<scope>test</scope>
 				<version>${version.wildfly}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.wildfly</groupId>
-				<artifactId>wildfly-controller</artifactId>
-				<version>${version.wildfly}</version>
-			</dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>${version.junit}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.logging</groupId>
-				<artifactId>jboss-logging</artifactId>
-				<version>${version.org.jboss.logging}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.logging</groupId>
-				<artifactId>jboss-logging-processor</artifactId>
-				<version>${version.org.jboss.logging.processor}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.logmanager</groupId>
-				<artifactId>jboss-logmanager</artifactId>
-				<version>${version.org.jboss.logmanager}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.shrinkwrap.resolver</groupId>
-				<artifactId>shrinkwrap-resolver-bom</artifactId>
-				<version>2.0.1</version>
-				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap.resolver</groupId>
 				<artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-				<version>2.0.1</version>
+				<version>2.2.0</version>
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap.resolver</groupId>
 				<artifactId>shrinkwrap-resolver-api</artifactId>
-				<version>2.0.1</version>
+				<version>2.2.0</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap.resolver</groupId>
 				<artifactId>shrinkwrap-resolver-spi</artifactId>
-				<version>2.0.1</version>
+				<version>2.2.0</version>
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap</groupId>
 				<artifactId>shrinkwrap-api</artifactId>
-				<version>1.1.2</version>
+				<version>1.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap</groupId>
 				<artifactId>shrinkwrap-spi</artifactId>
-				<version>1.1.2</version>
+				<version>1.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap</groupId>
 				<artifactId>shrinkwrap-impl-base</artifactId>
-				<version>1.1.2</version>
+				<version>1.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
@@ -190,16 +140,6 @@
 						<artifactId>xml-apis</artifactId>
 					</exclusion>
 				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-entitymanager</artifactId>
-				<version>${version.org.hibernate}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-envers</artifactId>
-				<version>${version.org.hibernate}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
@@ -277,9 +217,9 @@
 					</configuration>
 					<dependencies>
 						<dependency>
-							<groupId>org.wildfly</groupId>
+							<groupId>org.wildfly.core</groupId>
 							<artifactId>wildfly-build-config</artifactId>
-							<version>${version.wildfly}</version>
+							<version>1.0.0.Alpha1</version>
 						</dependency>
 					</dependencies>
 					<executions>

--- a/test-ear/pom.xml
+++ b/test-ear/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.wildfly.extras.db_bootstrap</groupId>
 		<artifactId>db-bootstrap-subsystem-parent</artifactId>
-		<version>1.0.7</version>
+		<version>1.0.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -43,7 +43,7 @@
 			            </goals>
 						<configuration>
 						    <finalName>wildfly-arquillian-integration-exploded-ear</finalName>
-							<version>6</version>
+							<version>7</version>
 							<generateApplicationXml>false</generateApplicationXml>
 							<modules>
 								<jarModule>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.wildfly.extras.db_bootstrap</groupId>
 		<artifactId>db-bootstrap-subsystem-parent</artifactId>
-		<version>1.0.7</version>
+		<version>1.0.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
So, I wanted to update the Hibernate version from 4 to 5 in db_bootstrap such that it doesn't conflict with version 5 in WildFly 10 (specifically, complains about deprecated dialects and who knows what else).

I decided to update everything when I was at it. I even tried to get the db_bootstrap module to use the Hibernate module that ships with WildFly but I ended up with class path issues I couldn't fix after using more than an hour. It cannot load the com.h2.Driver class even though I include the H2 module (I even tried via jboss-deployment-structure.xml in addition to the dependency in the db_bootstrap module.xml).

I should also have updated the parent from org.jboss.jboss-parent to org.wildfly.wildfly-parent but it resulted in a lot of checkstyle crap because of some dependencies being included in different versions. I don't know. My life is too short for this... especially when we want to get rid of db_bootstrap.

At least we know have the same version of Hibernate in WildFly and in db_bootstrap even thought we still have the damn extra jars bundled with db_bootstrap.
